### PR TITLE
bm/structured-parse-output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ Cargo.lock
 models.dot
 feather_flow/demo_project
 demo_project/financial_demo.duckdb
+demo_project/output.yml
 **/.claude/settings.local.json
 models.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,21 @@ Available commands:
   parse    Parse SQL files and build a dependency graph
   version  Show version information
 ```
+
+## Parse Command Options
+```
+ff parse [OPTIONS] --model-path <MODEL_PATH>
+
+Options:
+  -m, --model-path <MODEL_PATH>    Path to the SQL model files
+  -f, --format <FORMAT>            Output format for the graph (dot, text, json, yaml) [default: text]
+  -o, --output-file <OUTPUT_FILE>  File to write output to (if not provided, output to stdout)
+```
+
+## Testing with Demo Project
+The demo project can be used to test FeatherFlow functionality:
+
+- `make parse_demo_project` - Runs the parser on the demo project and outputs a YAML file to demo_project/output.yml
+  - This generates a complete model graph with dependencies, columns, and metadata
+
+The output YAML can be used for testing or feeding into other tools to visualize model structure.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_DIR := feather_flow
 
 include $(PROJECT_DIR)/feather_flow.mk
 
-.PHONY: all build fmt lint clippy test test-module test-single test-verbose run parse-example parse-dot parse-json clean help ci-test release install-target target target-release target-aarch64-linux prepare-binary install-local ff-local version
+.PHONY: all build fmt lint clippy test test-module test-single test-verbose run parse-example parse-dot parse-json parse_demo_project clean help ci-test release install-target target target-release target-aarch64-linux prepare-binary install-local ff-local version
 
 all: build ## Default target, builds the project
 
@@ -43,6 +43,11 @@ parse-json: build ## Generate JSON representation from example models
 	@echo "Generating JSON representation of example models..."
 	@cd $(PROJECT_DIR) && cargo run -- parse --model-path ./models --format json > models.json
 	@echo "JSON saved to $(PROJECT_DIR)/models.json"
+
+parse_demo_project: build ## Run parser on demo project and output YAML to a file
+	@echo "Running parser on demo project and outputting to YAML..."
+	@cd $(PROJECT_DIR) && cargo run -- parse --model-path ../demo_project/models --format yaml --output-file ../demo_project/output.yml
+	@echo "YAML saved to: $(shell pwd)/demo_project/output.yml"
 
 
 rust-folder-structure: ## Check project structure and dependencies

--- a/feather_flow/src/main.rs
+++ b/feather_flow/src/main.rs
@@ -22,9 +22,13 @@ enum Command {
         #[clap(short, long)]
         model_path: PathBuf,
 
-        /// Output format for the graph (dot, text, json)
+        /// Output format for the graph (dot, text, json, yaml)
         #[clap(short, long, default_value = "text")]
         format: String,
+
+        /// File to write output to (if not provided, output to stdout)
+        #[clap(short, long)]
+        output_file: Option<String>,
     },
 
     /// Validate model file structure
@@ -46,9 +50,15 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Parse { model_path, format } => {
+        Command::Parse {
+            model_path,
+            format,
+            output_file,
+        } => {
             // Run the parse command with validation always enabled
-            if let Err(err) = commands::parse::parse_command(&model_path, &format, true) {
+            if let Err(err) =
+                commands::parse::parse_command(&model_path, &format, true, output_file.as_deref())
+            {
                 eprintln!("Error: {}", err);
                 process::exit(1);
             }


### PR DESCRIPTION
## Describe your code changes

This pull request introduces YAML support for the FeatherFlow project, enabling users to output SQL model dependency graphs in YAML format. It also adds functionality to write the output to a file and includes a demo project for testing. The most important changes include updates to the `parse` command, enhancements to the `Makefile`, and new methods for handling YAML output.

### New Features and Enhancements:

* **YAML Output Support**:
  - Added a new YAML output format for SQL model dependency graphs, along with data structures (`YamlOutput`, `YamlOutputModel`, `YamlOutputColumn`) to represent the YAML schema. (`feather_flow/src/sql_engine/sql_model.rs`, [[1]](diffhunk://#diff-5512f3074ab4b7ddea44e026ffd6c5451f2156b5f54d5d39fd2874b120e07c44R26-R58) [[2]](diffhunk://#diff-5512f3074ab4b7ddea44e026ffd6c5451f2156b5f54d5d39fd2874b120e07c44R458-R508)
  - Introduced `output_yaml_format` and `write_yaml_to_file` methods to handle YAML output to stdout and files, respectively. (`feather_flow/src/commands/parse.rs`, [feather_flow/src/commands/parse.rsR323-R352](diffhunk://#diff-365b30836769d3ed39fb461cb766b23c2a47f1d97391394dcaac1c0a632ed7daR323-R352))

* **File Output for Parse Command**:
  - Enhanced the `parse` command to support an optional `--output-file` parameter, allowing users to write the output to a specified file. (`feather_flow/src/main.rs`, [[1]](diffhunk://#diff-16a993f3319699e0444bb8f8eec9a6eb5b687ee540a490239ba0f166e70727b7L25-R31) [[2]](diffhunk://#diff-16a993f3319699e0444bb8f8eec9a6eb5b687ee540a490239ba0f166e70727b7L49-R61); `feather_flow/src/commands/parse.rs`, F31a1ed2L121R148)

### Developer Tools and Documentation:

* **Demo Project for Testing**:
  - Added a `parse_demo_project` target in the `Makefile` to parse a demo project and output the results in YAML format. This facilitates testing and visualization of model structure. (`Makefile`, [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R47-R51) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R5)
  - Updated `CLAUDE.md` with instructions for using the `parse` command and testing with the demo project. (`CLAUDE.md`, [CLAUDE.mdR44-R61](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R44-R61))



## Why do we need this from a business lens?

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
